### PR TITLE
Refactored project into standard format. Closes #30.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -19,7 +19,15 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -30,6 +38,11 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>

--- a/src/main/java/com/dart/explore/entity/Amenity.java
+++ b/src/main/java/com/dart/explore/entity/Amenity.java
@@ -1,5 +1,5 @@
 // Amenity.java
-package com.dart.entity;
+package com.dart.explore.entity;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/dart/explore/entity/AmenityId.java
+++ b/src/main/java/com/dart/explore/entity/AmenityId.java
@@ -1,4 +1,4 @@
-package com.dart.entity;
+package com.dart.explore.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;

--- a/src/main/java/com/dart/explore/entity/PointOfInterest.java
+++ b/src/main/java/com/dart/explore/entity/PointOfInterest.java
@@ -1,4 +1,4 @@
-package com.dart.entity;
+package com.dart.explore.entity;
 
 import javax.persistence.*;
 import java.util.List;

--- a/src/main/java/com/dart/explore/entity/Station.java
+++ b/src/main/java/com/dart/explore/entity/Station.java
@@ -1,4 +1,4 @@
-package com.dart.entity;
+package com.dart.explore.entity;
 
 import javax.persistence.*;
 import java.util.List;

--- a/src/main/java/com/dart/explore/entity/StationColor.java
+++ b/src/main/java/com/dart/explore/entity/StationColor.java
@@ -1,4 +1,4 @@
-package com.dart.entity;
+package com.dart.explore.entity;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/dart/explore/entity/StationColorId.java
+++ b/src/main/java/com/dart/explore/entity/StationColorId.java
@@ -1,4 +1,4 @@
-package com.dart.entity;
+package com.dart.explore.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;

--- a/src/main/java/com/dart/explore/entity/StationConnection.java
+++ b/src/main/java/com/dart/explore/entity/StationConnection.java
@@ -1,4 +1,4 @@
-package com.dart.entity;
+package com.dart.explore.entity;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/dart/explore/entity/StationConnectionId.java
+++ b/src/main/java/com/dart/explore/entity/StationConnectionId.java
@@ -1,4 +1,4 @@
-package com.dart.entity;
+package com.dart.explore.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;

--- a/src/main/java/com/dart/explore/main/ExploreApplication.java
+++ b/src/main/java/com/dart/explore/main/ExploreApplication.java
@@ -1,4 +1,4 @@
-package com.dart.explore;
+package com.dart.explore.main;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/dart/explore/repository/AmenityRepository.java
+++ b/src/main/java/com/dart/explore/repository/AmenityRepository.java
@@ -1,6 +1,6 @@
-package com.dart.repository;
+package com.dart.explore.repository;
 
-import com.dart.entity.Amenity;
+import com.dart.explore.entity.Amenity;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AmenityRepository extends CrudRepository<Amenity, Long> {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/DartApp
-spring.datasource.username=admin
+spring.datasource.url=jdbc:mysql://localhost:3306/dart_explore
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=root
 spring.datasource.password=password
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Refactored folders into standard format for Maven projects. All packages are now prefixed by com.dart.explore. Closes #30 .