### PR TITLE
Updated to name and mocked importService to fix error

### DIFF
--- a/src/test/java/com/dart/explore/repository/StationRepositoryTest.java
+++ b/src/test/java/com/dart/explore/repository/StationRepositoryTest.java
@@ -2,11 +2,13 @@ package com.dart.explore.repository;
 
 import com.dart.explore.entity.Station;
 import com.dart.explore.entity.StationColor;
+import com.dart.explore.service.ImportService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
 
@@ -21,20 +23,25 @@ public class StationRepositoryTest {
     @Autowired
     private StationRepository stationRepository;
 
+    @MockBean
+    private ImportService importService;
+
     @Test
     public void whenFindByColor_thenReturnStations() {
         // given
-        Station grandCentral = new Station();
-        grandCentral.setName("Grand Central");
-        grandCentral.getColor().add(StationColor.GREEN);
-        entityManager.persist(grandCentral);
+        Station testStation = new Station();
+        testStation.setName("This is a test station");
+        testStation.getColor().add(StationColor.GREEN);
+        entityManager.persist(testStation);
         entityManager.flush();
 
         // when
         List<Station> found = stationRepository.getStationsByLine(StationColor.GREEN);
 
         // then
-        assertThat(found).hasSize(1);
-        assertThat(found.get(0).getName()).isEqualTo(grandCentral.getName());
+        // tests that both the return and the add worked since the count is 18 + 1 we added
+        assertThat(found).hasSize(19);
+        // tests that we can data is coming back correctly since we can correctly match the name
+        assertThat(found.get(found.size() - 1).getName()).isEqualTo(testStation.getName());
     }
 }


### PR DESCRIPTION
closes #85. So there's kind of a lot of little things that I find out with this

- I don't think we should be mocking the importService in the future since it's not required for the test. I just didn't want to write a configuration file for the file and then use the @SpringBootTest annotation, but I do think we should do that in the future.
- Depending on how hosting goes, we might actually have a server that hosts the application and another that hosts the server (which makes sense thinking about it now) and in which case, we'd probably be better off keeping the txt files with the database and coping them into the table. This brings up -
- Ideally, we'd let the application initialize the schema imo, and then have the data loaded, but if the data is with the database server, the steps would be, start the database, start the application to load the schema, and then load the data. Which seems clunky. However it still seems like it might be "better" than storing the data with the app, like organically discussed.  